### PR TITLE
feat: Integrate Eurostat API for EU forest area data

### DIFF
--- a/eco_project/backend/app.py
+++ b/eco_project/backend/app.py
@@ -82,6 +82,71 @@ def forest_area():
         )
         return jsonify({"error": str(e)}), 500
 
+@app.route('/api/eu_forest_area')
+def eu_forest_area():
+    # Eurostat API URL for forest area for EU countries
+    # Dataset: sdg_15_11
+    url = "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/sdg_15_11?format=JSON&lang=en&time=2020"
+
+    try:
+        response = requests.get(url)
+        data = response.json()
+
+        if data and 'value' in data:
+            # Clean and format the data
+            formatted_data = []
+            # Create a mapping from country code to country name
+            geo_labels = data.get('dimension', {}).get('geo', {}).get('category', {}).get('label', {})
+
+            # The API response has a flat list of values, and the order corresponds to the order of dimensions.
+            # We need to iterate through the geo dimension to get the correct values.
+            geo_categories = data.get('dimension', {}).get('geo', {}).get('category', {}).get('index', {})
+
+            for country_code, index in geo_categories.items():
+                value = data['value'][index]
+                country_label = geo_labels.get(country_code, country_code) # Fallback to code if label not found
+                formatted_data.append({
+                    'country': country_label,
+                    'country_code': country_code,
+                    'year': '2020',
+                    'value': value
+                })
+
+            # Log the successful data fetch
+            logger.log_struct(
+                {
+                    "message": "Successfully fetched EU forest area data.",
+                    "component": "backend",
+                    "endpoint": "/api/eu_forest_area",
+                },
+                severity="INFO",
+            )
+
+            return jsonify(formatted_data)
+        else:
+            logger.log_struct(
+                {
+                    "message": "No data found for the selected criteria.",
+                    "component": "backend",
+                    "endpoint": "/api/eu_forest_area",
+                    "url": url,
+                },
+                severity="WARNING",
+            )
+            return jsonify({"error": "No data found for the selected criteria."}), 404
+
+    except requests.exceptions.RequestException as e:
+        logger.log_struct(
+            {
+                "message": f"Error fetching data from Eurostat API: {e}",
+                "component": "backend",
+                "endpoint": "/api/eu_forest_area",
+                "url": url,
+            },
+            severity="ERROR",
+        )
+        return jsonify({"error": str(e)}), 500
+
 if __name__ == '__main__':
     port = int(os.environ.get("PORT", 8080))
     app.run(host='0.0.0.0', port=port, debug=False)

--- a/eco_project/frontend/index.html
+++ b/eco_project/frontend/index.html
@@ -27,6 +27,8 @@
             <h2>Development Projects</h2>
             <p>Tracking and managing sustainable development goals. Here is some data from the World Bank:</p>
             <div id="world-bank-data"></div>
+            <p>And here is some data from Eurostat:</p>
+            <div id="eurostat-data"></div>
         </section>
         <section id="ai-agent">
             <h2>AI Assistant</h2>

--- a/eco_project/frontend/script.js
+++ b/eco_project/frontend/script.js
@@ -3,9 +3,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const chatInput = document.getElementById('chat-input');
     const chatWindow = document.getElementById('chat-window');
     const worldBankDataContainer = document.getElementById('world-bank-data');
+    const eurostatDataContainer = document.getElementById('eurostat-data');
 
     // Fetch and display World Bank data on page load
     fetchWorldBankData();
+    fetchEurostatData();
 
     sendBtn.addEventListener('click', () => {
         const userInput = chatInput.value;
@@ -50,6 +52,32 @@ document.addEventListener('DOMContentLoaded', () => {
 
         } catch (error) {
             worldBankDataContainer.innerHTML = `<p>Error fetching data: ${error.message}</p>`;
+        }
+    }
+
+    async function fetchEurostatData() {
+        try {
+            const response = await fetch('/api/eu_forest_area');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json();
+
+            if (data.error) {
+                eurostatDataContainer.innerHTML = `<p>Error fetching data: ${data.error}</p>`;
+                return;
+            }
+
+            let html = '<ul>';
+            data.forEach(item => {
+                html += `<li>${item.country}: ${item.value ? item.value.toFixed(2) : 'N/A'}% (${item.year})</li>`;
+            });
+            html += '</ul>';
+
+            eurostatDataContainer.innerHTML = html;
+
+        } catch (error) {
+            eurostatDataContainer.innerHTML = `<p>Error fetching data: ${error.message}</p>`;
         }
     }
 });


### PR DESCRIPTION
This commit introduces a new feature to the application by integrating the Eurostat API to fetch and display forest area data for EU countries.

- A new backend endpoint `/api/eu_forest_area` has been added to `eco_project/backend/app.py`. This endpoint queries the Eurostat API for the `sdg_15_11` dataset, which contains information about forest area.
- The frontend has been updated to consume this new endpoint.
- A new section has been added to `index.html` to display the data from Eurostat.
- `script.js` has been modified to include a new function `fetchEurostatData` that fetches the data from the new endpoint and renders it on the page.

## Summary by Sourcery

Integrate the Eurostat API into the application by introducing a new backend endpoint for EU forest area data and updating the frontend to fetch and display this data in the UI.

New Features:
- Add /api/eu_forest_area backend endpoint to fetch and format 2020 forest area data from the Eurostat API
- Implement fetchEurostatData() in the frontend to retrieve and display Eurostat forest area percentages for EU countries
- Update index.html to include a new section and container for presenting Eurostat forest area data