### PR TITLE
Feature/configure gcloud credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+eco_project/backend/gcloud-credentials.json

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,56 @@
 steps:
+# Build the backend image
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/backend:latest', './eco_project/backend']
+
+# Copy static files to the frontend directory.
 - name: 'ubuntu'
   args: ['cp', '-a', 'eco_project/backend/static/.', 'eco_project/frontend/']
+
+# Build the frontend image
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/frontend:latest', './eco_project/frontend']
+
+# Deploy the backend to Cloud Run
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args:
+    - 'run'
+    - 'deploy'
+    - 'backend'
+    - '--image=gcr.io/$PROJECT_ID/backend:latest'
+    - '--platform=managed'
+    - '--region=us-central1'
+    - '--allow-unauthenticated'
+    - '--port=8080'
+    - '--project=$PROJECT_ID'
+
+# Get the backend URL and store it in a file
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      gcloud run services describe backend --platform=managed --region=us-central1 --format='value(status.url)' --project=$PROJECT_ID > /workspace/backend_url.txt
+
+# Deploy the frontend to Cloud Run, using the backend URL
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      BACKEND_URL=$$(cat /workspace/backend_url.txt)
+      gcloud run deploy frontend \
+        --image=gcr.io/$PROJECT_ID/frontend:latest \
+        --platform=managed \
+        --region=us-central1 \
+        --allow-unauthenticated \
+        --port=8080 \
+        --set-env-vars="BACKEND_URL=$$BACKEND_URL" \
+        --project=$PROJECT_ID
+
 images:
 - 'gcr.io/$PROJECT_ID/backend:latest'
 - 'gcr.io/$PROJECT_ID/frontend:latest'
+
+timeout: 1200s

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,30 +29,7 @@ gcloud services enable run.googleapis.com
 gcloud services enable containerregistry.googleapis.com
 
 # Submit the build to Cloud Build
-echo "Building and pushing Docker images..."
+echo "Starting the build and deployment process..."
 gcloud builds submit --config cloudbuild.yaml .
 
-# Deploy backend to Cloud Run
-echo "Deploying backend to Cloud Run..."
-gcloud run deploy backend \
-  --image="gcr.io/$GOOGLE_CLOUD_PROJECT/backend:latest" \
-  --platform=managed \
-  --region=us-central1 \
-  --allow-unauthenticated \
-  --port=8080
-
-# Get the backend URL
-BACKEND_URL=$(gcloud run services describe backend --platform=managed --region=us-central1 --format='value(status.url)')
-
-# Deploy frontend to Cloud Run
-echo "Deploying frontend to Cloud Run..."
-gcloud run deploy frontend \
-  --image="gcr.io/$GOOGLE_CLOUD_PROJECT/frontend:latest" \
-  --platform=managed \
-  --region=us-central1 \
-  --allow-unauthenticated \
-  --port=8080 \
-  --set-env-vars=BACKEND_URL=$BACKEND_URL
-
-echo "Deployment complete."
-echo "Frontend URL: $(gcloud run services describe frontend --platform=managed --region=us-central1 --format='value(status.url)')"
+echo "Cloud Build has been triggered. Monitor the build progress in the Google Cloud Console."

--- a/eco_project/backend/app.py
+++ b/eco_project/backend/app.py
@@ -8,7 +8,7 @@ class MockLogger:
         pass  # Does nothing
 
 # Conditionally initialize the logger
-if os.environ.get('GAE_ENV') == 'standard':
+if os.environ.get('GOOGLE_APPLICATION_CREDENTIALS'):
     from google.cloud import logging as cloud_logging
     logging_client = cloud_logging.Client()
     log_name = "world-bank-api-logs"

--- a/eco_project/docker-compose.yml
+++ b/eco_project/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     restart: always
     environment:
       - OLLAMA_API_URL=http://host.docker.internal:11434/api/generate
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/gcloud-credentials.json
+    volumes:
+      - ./backend/gcloud-credentials.json:/app/gcloud-credentials.json
   frontend:
     build:
       context: .


### PR DESCRIPTION
## Summary by Sourcery

Configure centralized build and deployment using Cloud Build and Cloud Run with support for Google Cloud service account credentials.

Enhancements:
- Redesign deploy.sh to trigger the Cloud Build pipeline instead of running gcloud deploy commands locally
- Expand cloudbuild.yaml to build backend and frontend images, deploy both services to Cloud Run, and propagate the backend URL as an environment variable
- Increase Cloud Build timeout and copy static assets from backend to frontend before building
- Allow mounting GOOGLE_APPLICATION_CREDENTIALS in docker-compose and initialize cloud logging when credentials are present

Chores:
- Add .gitignore entry