### PR TITLE
Integrate Environmental Podcast Page

### DIFF
--- a/eco_project/backend/static/index.html
+++ b/eco_project/backend/static/index.html
@@ -57,6 +57,7 @@
                 <li><a href="forest_seeds.html">Forest Seeds Promotion</a></li>
                 <li><a href="chat.html">Join the Chat</a></li>
                 <li><a href="sports.html">Watch Sports</a></li>
+                <li><a href="podcast.html">Listen to Podcasts</a></li>
                 <li><a href="air_quality.html">Air Quality</a></li>
                 <li><a href="unep.html">UNEP Data</a></li>
             </ul>

--- a/eco_project/backend/static/podcast.css
+++ b/eco_project/backend/static/podcast.css
@@ -1,0 +1,60 @@
+#podcast-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.podcast-card {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 15px;
+    background-color: #f9f9f9;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    transition: transform 0.2s;
+}
+
+.podcast-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.podcast-card img {
+    max-width: 100%;
+    border-radius: 4px;
+    margin-bottom: 10px;
+}
+
+.podcast-card h3 {
+    margin: 10px 0 5px 0;
+    font-size: 1.2em;
+}
+
+.podcast-card p {
+    margin: 5px 0;
+    color: #666;
+}
+
+.podcast-card a {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 8px 16px;
+    background-color: #2e7d32;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+}
+
+.podcast-card a:hover {
+    background-color: #1b5e20;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 20px;
+    text-decoration: none;
+    color: #2e7d32;
+}

--- a/eco_project/backend/static/podcast.html
+++ b/eco_project/backend/static/podcast.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Environmental Podcasts - Environment Protection</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="podcast.css">
+</head>
+<body>
+    <header>
+        <h1>Environmental Podcasts</h1>
+        <nav>
+            <a href="index.html">Home</a>
+        </nav>
+    </header>
+    <main>
+        <section id="podcasts">
+            <h2>Listen to Podcasts</h2>
+            <div id="podcast-container">
+                <!-- Podcast content will be loaded here -->
+                <p>Loading podcasts...</p>
+            </div>
+        </section>
+        <a href="index.html" class="back-link">Back to Home</a>
+    </main>
+    <footer>
+        <p>&copy; 2025 Environment Protection Initiative</p>
+    </footer>
+    <script src="podcast.js"></script>
+</body>
+</html>

--- a/eco_project/backend/static/podcast.js
+++ b/eco_project/backend/static/podcast.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const podcastContainer = document.getElementById('podcast-container');
+
+    // iTunes Search API for environmental podcasts
+    const apiUrl = 'https://itunes.apple.com/search?term=environment&entity=podcast&limit=15';
+
+    fetch(apiUrl)
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            return response.json();
+        })
+        .then(data => {
+            podcastContainer.innerHTML = ''; // Clear loading message
+
+            if (!data.results || data.results.length === 0) {
+                podcastContainer.innerHTML = '<p>No podcasts found.</p>';
+                return;
+            }
+
+            data.results.forEach(podcast => {
+                const podcastCard = document.createElement('div');
+                podcastCard.classList.add('podcast-card');
+
+                const img = document.createElement('img');
+                img.src = podcast.artworkUrl600 || podcast.artworkUrl100;
+                img.alt = podcast.collectionName;
+
+                const h3 = document.createElement('h3');
+                h3.textContent = podcast.collectionName;
+
+                const artistP = document.createElement('p');
+                artistP.innerHTML = `<strong>Artist:</strong> `;
+                const artistSpan = document.createElement('span');
+                artistSpan.textContent = podcast.artistName;
+                artistP.appendChild(artistSpan);
+
+                const genreP = document.createElement('p');
+                genreP.innerHTML = `<strong>Genre:</strong> `;
+                const genreSpan = document.createElement('span');
+                genreSpan.textContent = podcast.primaryGenreName;
+                genreP.appendChild(genreSpan);
+
+                const link = document.createElement('a');
+                link.href = podcast.collectionViewUrl;
+                link.target = "_blank";
+                link.textContent = "View on Apple Podcasts";
+
+                podcastCard.appendChild(img);
+                podcastCard.appendChild(h3);
+                podcastCard.appendChild(artistP);
+                podcastCard.appendChild(genreP);
+                podcastCard.appendChild(link);
+
+                podcastContainer.appendChild(podcastCard);
+            });
+        })
+        .catch(error => {
+            console.error('There has been a problem with your fetch operation:', error);
+            podcastContainer.innerHTML = '<p>Could not fetch podcast data. Please try again later.</p>';
+        });
+});


### PR DESCRIPTION
Integrated a new podcast page into the environmental project. The page fetches live data from the iTunes Search API using the term 'environment'. It features a responsive grid of podcast cards with artwork, titles, artists, and links to Apple Podcasts. Updated the main index page to link to this new feature.

---
*PR created automatically by Jules for task [18113532683206649785](https://jules.google.com/task/18113532683206649785) started by @GYFX35*

## Summary by Sourcery

Add an environmental podcasts page that surfaces external podcast content and link it from the main site navigation.

New Features:
- Introduce a dedicated Environmental Podcasts page that loads podcast metadata from the iTunes Search API and displays it in a responsive card grid.

Enhancements:
- Update the main index page navigation to include an entry for the new podcasts page.